### PR TITLE
Fixed bug with heat creation in breeders

### DIFF
--- a/TileEntities/Fission/Breeder/TileEntityBreederCore.java
+++ b/TileEntities/Fission/Breeder/TileEntityBreederCore.java
@@ -100,29 +100,33 @@ public class TileEntityBreederCore extends TileEntityNuclearCore {
 		if (!world.isRemote) {
 			if (this.isPoisoned())
 				return true;
-			if (ReikaRandomHelper.doWithChance(0.0125)) {
-				int slot = ReikaInventoryHelper.locateInInventory(ReactorItems.BREEDERFUEL.getShiftedItemID(), inv);
-				if (slot != -1) {
-					int dmg = inv[slot].getItemDamage();
-					if (dmg == ReactorItems.BREEDERFUEL.getNumberMetadatas()-1) {
-						inv[slot] = ReactorItems.PLUTONIUM.getStackOf();
-						ReactorAchievements.PLUTONIUM.triggerAchievement(this.getPlacer());
-					}
-					else {
-						inv[slot] = ReactorItems.BREEDERFUEL.getStackOfMetadata(dmg+1);
-					}
-					temperature += 50;
-					this.spawnNeutronBurst(world, x, y, z);
+			if (this.isFissile() && ReikaRandomHelper.doWithChance(25)) {
+				if (ReikaRandomHelper.doWithChance(5)) {
+					// Note: this will happen 1.25% of the time
+					int slot = ReikaInventoryHelper.locateInInventory(ReactorItems.BREEDERFUEL.getShiftedItemID(), inv);
+					if (slot != -1) {
+						int dmg = inv[slot].getItemDamage();
+						if (dmg == ReactorItems.BREEDERFUEL.getNumberMetadatas()-1) {
+							inv[slot] = ReactorItems.PLUTONIUM.getStackOf();
+							ReactorAchievements.PLUTONIUM.triggerAchievement(this.getPlacer());
+						}
+						else {
+							inv[slot] = ReactorItems.BREEDERFUEL.getStackOfMetadata(dmg+1);
+						}
+						temperature += 50;
+						this.spawnNeutronBurst(world, x, y, z);
 
-					if (ReikaRandomHelper.doWithChance(10)) {
-						this.addWaste();
+						if (ReikaRandomHelper.doWithChance(10)) {
+							this.addWaste();
+						}
 					}
-
-					return true;
 				}
+				else
+					// Note: this will happen 23.75% of the time
+					temperature += temperature >= 700 ? 30 : 20;
+				return true;
 			}
-			else
-				temperature += temperature >= 700 ? 30 : 20;
+			// Note: 75% of the time, we let the neutron pass unhindered
 		}
 		return false;
 	}


### PR DESCRIPTION
When a neutron passes through a breeder (assuming it is not poisoned) and does not enrich the fuel, it adds 20 or 30 heat and is not stopped. This means you got free heat out of the neutron, 98.75% of the time. And the neutron will continue on after, perhaps to give you free heat in subsequent cores.

This means that a single neutron, instead of the intended maximum of roughly 30 temperature units, can be convinced to produce an enormous amount of temperature (and correspondingly enormous amounts of steam).

The simplest solution here is to add a 'return true;' after the temperature absorption, though this makes empty breeder cores the best neutron blocking item in the game! 100% of neutrons stopped and turned into heat! Plus, it doesn't even use fuel!

The solution I have implemented in this patch uses similar code to the standard fuel rod. First, if the breeder is empty it acts like air (100% pass through). If it has fuel, then it has a 1.25% chance of enriching the fuel and producing heat, a 23.75% chance of absorbing the neutron into heat (using the current >= 700 ? 30 : 20), and a 75% of letting the neutron pass through.
