### PR TITLE
Fix server exception in radiation effect

### DIFF
--- a/Auxiliary/PotionRadiation.java
+++ b/Auxiliary/PotionRadiation.java
@@ -42,8 +42,7 @@ public class PotionRadiation extends Potion {
 
 		if (e instanceof EntityPlayer) {
 			EntityPlayer ep = (EntityPlayer)e;
-			ep.getFoodStats().setFoodSaturationLevel(0);
-			ep.getFoodStats().setFoodLevel(1);
+			ep.getFoodStats().addExhaustion(40);
 
 			ReikaPlayerAPI.setPlayerWalkSpeed(ep, 0.075F);
 		}


### PR DESCRIPTION
The food and saturation levels cannot be set directly, those are client-side only methods. Set the exhaustion level to the maximum instead, which will cause the player's hunger bar to drop quickly.
