### PR TITLE
Fixed HiPT Tile bug

### DIFF
--- a/Registry/WorkingFluid.java
+++ b/Registry/WorkingFluid.java
@@ -36,7 +36,7 @@ public enum WorkingFluid {
 	}
 
 	public Fluid getLowPressureFluid() {
-		return FluidRegistry.getFluid("lowp"+this.name().toLowerCase());
+		return FluidRegistry.getFluid("rc lowp"+this.name().toLowerCase());
 	}
 
 	public static WorkingFluid getFromNBT(NBTTagCompound NBT) {


### PR DESCRIPTION
Hi,
in commit ed0853fe93c43fa099aa97ed9ec016e5d1dfc91e you updatet "lowpwater" to "rc lowpwater".

In this case, the HiPR::dumpStream method requires an fluid, wich Forge doesn't know.

Here the stacktrace:
[18:50:51] [Server thread/INFO] [FML]: Tile Entity High-Pressure Turbine @ DIM0: -10, 78, -26 is throwing class java.lang.NullPointerException on update: null
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]: java.lang.NullPointerException
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraftforge.fluids.FluidStack.<init>(FluidStack.java:27)
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at Reika.ReactorCraft.TileEntities.PowerGen.TileEntityHiPTurbine.dumpSteam(TileEntityHiPTurbine.java:155)
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at Reika.ReactorCraft.TileEntities.PowerGen.TileEntityTurbineCore.updateEntity(TileEntityTurbineCore.java:147)
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at Reika.DragonAPI.Base.TileEntityBase.func_145845_h(TileEntityBase.java:388)
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraft.world.World.func_72939_s(World.java:1939)
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489)
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636)
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334)
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
[18:50:51] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)


Best regards,
Kevin
